### PR TITLE
Updated footstepper to use a queue of audio players instead of just one

### DIFF
--- a/footstepper/plugin.cfg
+++ b/footstepper/plugin.cfg
@@ -3,5 +3,5 @@
 name="Footstepper"
 description="Simple movement sound node"
 author="Dragon1Freak"
-version="1.0.0"
+version="1.0.1"
 script="plugin.gd"


### PR DESCRIPTION
Adds a queue of players to handle the footstepper sounds.  Fixes a bug where two sounds happening at the same time would only play the first one, ie if you land during a buffered jump, only the jump sound plays.